### PR TITLE
Fix duplicate bean names

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/CaseEventsApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/CaseEventsApi.java
@@ -14,7 +14,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi.SERVICE_AUTHORIZATION;
 
 @FeignClient(
-    name = "core-case-data-api",
+    name = "core-case-event-api",
     url = "${core_case_data.api.url}",
     configuration = CoreCaseDataConfiguration.class
 )


### PR DESCRIPTION
### Change description

Removing the duplicate FeignClient names.

https://github.com/hmcts/ccd-client/blob/master/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataApi.java#L27
https://github.com/hmcts/ccd-client/blob/master/src/main/java/uk/gov/hmcts/reform/ccd/client/CaseEventsApi.java#L17

This causes thus error.

```
OverrideException: Invalid bean definition with name 'core-case-data-api.FeignClientSpecification' defined in null: Cannot register bean definition [Generic bean: class [org.springframework.cloud.openfeign.FeignClientSpecification]; scope=; abstract=false; lazyInit=null; autowireMode=0; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=null; factoryMethodName=null; initMethodName=null; destroyMethodName=null] for bean 'core-case-data-api.FeignClientSpecification': There is already [Generic bean: class [org.springframework.cloud.openfeign.FeignClientSpecification]; scope=; abstract=false; lazyInit=null; autowireMode=0; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=null; factoryMethodName=null; initMethodName=null; destroyMethodName=null] bound.
```



### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Task list and task completeness checks updated
- [ ] Check and send page updated
- [ ] Routes, page content and page flows of new features are toggled 
- [ ] UI changes look good on mobile
- [ ] Required Google Analytics events are being sent 

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
